### PR TITLE
Add enforcement section, clarify solicitation

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -43,11 +43,19 @@
 			<p>Participants asked to stop any harassing or inappropriate behavior are expected to comply immediately.</p>
 		</section>
 
+		<section aria-labelledby="enforcement">
+			<h2 id="enforcement">Enforcement</h2>
+			<p>Often, we follow a 3-strikes-and-you're-out rule where admins provide feedback on problematic behavior in a private DM with the hope that a person can improve their conduct. Sometimes this is appropriate when the issue is a difference in communication style or disagreements about group policy. We also keep in mind that we are an accessibility group with many neurodivergent members.</p>
+			<p>That said, sometimes conduct can be severe or harmful enough that we reserve the right to ban someone immediately.</p>
+			<p>As an admin group, we do our best to resolve disagreements with fairness and understanding. We strive to resolve Code of Conduct issues as peacefully as possible.</p>
+		</section>
+
 		<section aria-labelledby="solicitations">
 			<h2 id="solicitations">Solicitation Policy</h2>
-			<p>It is important to recognize that accessibility professionals in this Slack community are providing their time and expertise for free. For this reason, we ask that participants follow these guidelines when requesting labor or promoting a product or service:</p>
+			<p>It is important to recognize that accessibility professionals in this Slack community are providing their time and expertise for free. For this reason, we ask that participants follow these guidelines when **requesting labor or promoting a product or service**:</p>
 			<ul>
 				<li><strong>Advertisements for a product or service</strong>, as well as requests for community feedback on a product or service, should only be posted in the <strong><code>#announcements</code></strong> channel. This applies equally to commercial products and services, as well as those that are fully or partially open-source.</li>
+				<li>Discussions about doing the work as accessibility practicioners is still appropriate in other channels, as long as members motivations and interests are clear. **Provide transparency by keeping your company and role updated in your profile and including disclaimers when you work on a given tool or at a given company.**</li>
 				<li>Note: Whether something could be considered advertising or education depends on who benefits. Education will benefit learners (e.g. developers, designers, etc.), while advertising largely benefits the advertisers.</li>
 				
 				<li><strong>Surveys</strong> should only be posted in the <strong><code>#surveys</code></strong> channel. When posting a survey, please respect participants' desire for transparency around how their personal information will be used, by including all of the following:

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -29,7 +29,6 @@
 				<li>Marcy Sutton Todd (lead) - <a href="https://github.com/marcysutton">@marcysutton</a></li>
 				<li>Alex Umstead</li>
 				<li>Cassey Lottman</li>
-				<li>James Sheasby Thomas</li>
 			</ul>
 			<p>We want this to be a friendly, pleasant, and harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, ethnicity, national origin, religion, or place of employment.</p>
 			<p>We do not tolerate harassment or intimidation of participants in any form. Nor do we allow ad hominem attacks, meaning attacks on a person's character rather than the substance of their argument. While disagreements do happen, we expect our community to be kind and professional.</p>

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -45,9 +45,9 @@
 
 		<section aria-labelledby="enforcement">
 			<h2 id="enforcement">Enforcement</h2>
-			<p>Often, we follow a 3-strikes-and-you're-out rule where admins provide feedback on problematic behavior in a private DM with the hope that a person can improve their conduct. Sometimes this is appropriate when the issue is a difference in communication style or disagreements about group policy. We also keep in mind that we are an accessibility group with many neurodivergent members.</p>
-			<p>That said, sometimes conduct can be severe or harmful enough that we reserve the right to ban someone immediately.</p>
-			<p>As an admin group, we do our best to resolve disagreements with fairness and understanding. We strive to resolve Code of Conduct issues as peacefully as possible.</p>
+			<p>We follow a 3-strikes-you're-out rule where admins provide feedback on problematic behavior in a private DM with the hope that a person can improve their conduct. Sometimes this is appropriate when the issue is a difference in communication style or disagreements about group policy. We also keep in mind that we are an accessibility group with many neurodivergent members.</p>
+			<p>That said, sometimes conduct can be severe or harmful enough that we reserve the right to ban someone immediately (an "insta-ban").</p>
+			<p>As an admin group, we do our best to resolve disagreements with fairness and understanding. We strive to uphold our Code of Conduct rules as peacefully as possible.</p>
 		</section>
 
 		<section aria-labelledby="solicitations">
@@ -55,7 +55,7 @@
 			<p>It is important to recognize that accessibility professionals in this Slack community are providing their time and expertise for free. For this reason, we ask that participants follow these guidelines when **requesting labor or promoting a product or service**:</p>
 			<ul>
 				<li><strong>Advertisements for a product or service</strong>, as well as requests for community feedback on a product or service, should only be posted in the <strong><code>#announcements</code></strong> channel. This applies equally to commercial products and services, as well as those that are fully or partially open-source.</li>
-				<li>Discussions about doing the work as accessibility practicioners is still appropriate in other channels, as long as members motivations and interests are clear. **Provide transparency by keeping your company and role updated in your profile and including disclaimers when you work on a given tool or at a given company.**</li>
+				<li>Discussions about _doing the work_ as accessibility practicioners is still appropriate in other channels, as long as members' motivations and interests are clear. **Provide transparency by keeping your company and role updated in your profile and including disclaimers when you work on a given tool or at a given company.**</li>
 				<li>Note: Whether something could be considered advertising or education depends on who benefits. Education will benefit learners (e.g. developers, designers, etc.), while advertising largely benefits the advertisers.</li>
 				
 				<li><strong>Surveys</strong> should only be posted in the <strong><code>#surveys</code></strong> channel. When posting a survey, please respect participants' desire for transparency around how their personal information will be used, by including all of the following:

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -26,9 +26,10 @@
 			<p>A11y is a Slack community of individuals passionate about accessibility who voice their opinions. It is a space to ask questions, help other people figure stuff out or chat about accessibility in general.</p>
 			<p>The current admins are:</p>
 			<ul>
-				<li>Marcy Sutton (lead) - <a href="https://github.com/marcysutton">@marcysutton</a></li>
+				<li>Marcy Sutton Todd (lead) - <a href="https://github.com/marcysutton">@marcysutton</a></li>
 				<li>Alex Umstead</li>
 				<li>Cassey Lottman</li>
+				<li>James Sheasby Thomas</li>
 			</ul>
 			<p>We want this to be a friendly, pleasant, and harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, ethnicity, national origin, religion, or place of employment.</p>
 			<p>We do not tolerate harassment or intimidation of participants in any form. Nor do we allow ad hominem attacks, meaning attacks on a person's character rather than the substance of their argument. While disagreements do happen, we expect our community to be kind and professional.</p>
@@ -48,6 +49,26 @@
 			<p>We follow a 3-strikes-you're-out rule where admins provide feedback on problematic behavior in a private DM with the hope that a person can improve their conduct. Sometimes this is appropriate when the issue is a difference in communication style or disagreements about group policy. We also keep in mind that we are an accessibility group with many neurodivergent members.</p>
 			<p>That said, sometimes conduct can be severe or harmful enough that we reserve the right to ban someone immediately (an "insta-ban").</p>
 			<p>As an admin group, we do our best to resolve disagreements with fairness and understanding. We strive to uphold our Code of Conduct rules as peacefully as possible.</p>
+		</section>
+
+		<section aria-labelledby="a11y">
+			<h2 id="a11y">Accessibility of Posted Content</h2>
+			<p>Ensure all content shared in Slack is accessible. This includes:</p>
+			<ul>
+				<li>Providing alternative text for images and graphics.</li>
+				<li>Providing captions and/or transcripts for media content.</li>
+				<li>Warning users about flashing or moving screens.</li>
+				<li>Using inclusive, plain language.</li>
+			</ul>
+		</section>
+
+		<section aria-labelledby="content">
+			<h2 id="content">Content Recommendations</h2>
+			<p>While A11y is a community to share one’s thoughts on accessibility, it is not a fully private space. Members may represent themselves as well as companies. For a member looking to limit their own liability in this space, it is recommended to clearly delineate facts from opinions.</p>
+				
+			<p>Do ensure that statements, articles, and recommendations are factually accurate and supported by evidence and testing. Cite your sources when posting in the workspace and to be mindful of the language you use when criticizing companies or individuals.</p>
+
+			<p>If you find yourself at the center of a lawsuit stemming from content in this group, please let the admins know. You can also contact the <a href="https://www.eff.org/">Electronic Frontier Foundation</a> or legal groups such as <a href="https://hls.harvard.edu/clinics/in-house-clinics/cyberlaw-clinic/">Harvard Cyberlaw Clinic</a>.</p>
 		</section>
 
 		<section aria-labelledby="solicitations">
@@ -84,31 +105,6 @@
 				<li>Repeated, unwanted requests are considered harassment and will not be tolerated.</li>
 			</ul>
 		</section>
-
-		<section aria-labelledby="a11y">
-			<h2 id="a11y">Accessibility of Posted Content</h2>
-			<p>Ensure all content shared in Slack is accessible. This includes:</p>
-			<ul>
-				<li>Providing alternative text for images and graphics.</li>
-				<li>Providing captions and/or transcripts for media content.</li>
-				<li>Warning users about flashing or moving screens.</li>
-				<li>Using inclusive, plain language.</li>
-			</ul>
-		</section>
-
-		<section aria-labelledby="content">
-			<h2 id="content">Content Recommendations</h2>
-			<p>While A11y is a community to share one’s thoughts on accessibility, it is not a fully private space. Members may represent themselves as well as companies. For a member looking to limit their own liability in this space, it is recommended to clearly delineate facts from opinions.</p>
-				
-			<p>Do ensure that statements, articles, and recommendations are factually accurate and supported by evidence and testing. Cite your sources when posting in the workspace and to be mindful of the language you use when criticizing companies or individuals.</p>
-		</section>
-		
-		<section aria-labelledby="logs-records">
-			<h2 id="logs-records">Logs and Records</h2>
-			<p><strong>Please be mindful that things you say here may at some point become public</strong>. We cannot prevent people from screencapping or otherwise logging this Slack. We also can't guarantee that every member's login credentials and logged-in devices are secure. Files uploaded here can be downloaded by anyone with a login. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.</p>
-			<p>We ask that members not repeatedly delete messages from Slack channels, either, as it affects the search history and creates gaps when users have commented.</p>
-			<p>If you have issues with a shared channel or any other related matter, contact Marcy Sutton for assistance.</p>
-		</section>
 		
 		<section id="harassment">
 			<h2 id="harassment">Harassment</h2>
@@ -141,6 +137,13 @@
 			<p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>
 			<p>If a participant engages in harassing behavior, the admins may take any action they deem appropriate, up to and including deactivation from this Slack and identifying the participant publicly as someone about whom we've received complaints.</p>
 			<p>Participants should not change their handle or create a new one to avoid accountability for past actions. Also, if someone has been banned from the group they are not allowed to rejoin under a different email address, name, etc.</p>
+		</section>
+		
+		<section aria-labelledby="logs-records">
+			<h2 id="logs-records">Logs and Records</h2>
+			<p><strong>Please be mindful that things you say here may at some point become public</strong>. We cannot prevent people from screencapping or otherwise logging this Slack. We also can't guarantee that every member's login credentials and logged-in devices are secure. Files uploaded here can be downloaded by anyone with a login. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.</p>
+			<p>We ask that members not repeatedly delete messages from Slack channels, either, as it affects the search history and creates gaps when users have commented.</p>
+			<p>If you have issues with a shared channel or any other related matter, contact Marcy Sutton for assistance.</p>
 		</section>
 		
 		<section aria-labelledby="credits">


### PR DESCRIPTION
Updates to the CoC:

1. Adding a section about enforcement, specifically the 3 strikes rule and instabans
2. Adding a bit more in the solicitations policy about discussion on tooling