### PR TITLE
Add new admins to code-of-conduct.html

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -29,6 +29,9 @@
 				<li>Marcy Sutton Todd (lead) - <a href="https://github.com/marcysutton">@marcysutton</a></li>
 				<li>Alex Umstead</li>
 				<li>Cassey Lottman</li>
+				<li>Bianca Zanardi - <a href="https://www.zbianca.com/">@zbianca</a></li>
+				<li>Jon Farrell - <a href="https://www.linkedin.com/in/jonmfarrell/">@jonmfarrell</a></li>
+				<li>James Sheasby Thomas - <a href="https://rightsaidjames.com/">@rightsaidjames</a></li>
 			</ul>
 			<p>We want this to be a friendly, pleasant, and harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, ethnicity, national origin, religion, or place of employment.</p>
 			<p>We do not tolerate harassment or intimidation of participants in any form. Nor do we allow ad hominem attacks, meaning attacks on a person's character rather than the substance of their argument. While disagreements do happen, we expect our community to be kind and professional.</p>


### PR DESCRIPTION
Listed new admins on the code of conduct, with names and personal links provided by each individual.