### PR TITLE
Rename solicitation channels

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -43,7 +43,7 @@
 			<p>Do ensure all content is accessible.</p>
 			<p>Do ensure that statements, articles, and recommendations are factually accurate and supported by evidence.</p>
 			<p>Don’t send Direct Messages (DMs) without clear consent.</p>
-			<p>Do not make product announcements (solicitations) in channels other than <strong><code>#announcements</code></strong>, even if they are open source. You are still welcome to have accessibility discussions in content channels as long as they are not product or service advertisements. See our full <a href="#solicitations">solicitation policy</a> below.</p>
+			<p>Do not make product announcements (solicitations) in channels other than <strong><code>#ads-and-surveys</code></strong>, even if they are open source. You are still welcome to have accessibility discussions in content channels as long as they are not product or service advertisements. See our full <a href="#solicitations">solicitation policy</a> below.</p>
 			<p>Participants asked to stop any harassing or inappropriate behavior are expected to comply immediately.</p>
 		</section>
 
@@ -68,7 +68,7 @@
 		<section aria-labelledby="content">
 			<h2 id="content">Content Recommendations</h2>
 			<p>While A11y is a community to share one’s thoughts on accessibility, it is not a fully private space. Members may represent themselves as well as companies. For a member looking to limit their own liability in this space, it is recommended to clearly delineate facts from opinions.</p>
-				
+
 			<p>Do ensure that statements, articles, and recommendations are factually accurate and supported by evidence and testing. Cite your sources when posting in the workspace and to be mindful of the language you use when criticizing companies or individuals.</p>
 
 			<p>If you find yourself at the center of a lawsuit stemming from content in this group, please let the admins know. You can also contact the <a href="https://www.eff.org/">Electronic Frontier Foundation</a> or legal groups such as <a href="https://hls.harvard.edu/clinics/in-house-clinics/cyberlaw-clinic/">Harvard Cyberlaw Clinic</a>.</p>
@@ -78,11 +78,11 @@
 			<h2 id="solicitations">Solicitation Policy</h2>
 			<p>It is important to recognize that accessibility professionals in this Slack community are providing their time and expertise for free. For this reason, we ask that participants follow these guidelines when **requesting labor or promoting a product or service**:</p>
 			<ul>
-				<li><strong>Advertisements for a product or service</strong>, as well as requests for community feedback on a product or service, should only be posted in the <strong><code>#announcements</code></strong> channel. This applies equally to commercial products and services, as well as those that are fully or partially open-source.</li>
+				<li><strong>Advertisements for a product or service</strong>, as well as requests for community feedback on a product or service, should only be posted in the <strong><code>#ads-and-surveys</code></strong> channel. This applies equally to commercial products and services, as well as those that are fully or partially open-source.</li>
 				<li>Discussions about _doing the work_ as accessibility practicioners is still appropriate in other channels, as long as members' motivations and interests are clear. **Provide transparency by keeping your company and role updated in your profile and including disclaimers when you work on a given tool or at a given company.**</li>
 				<li>Note: Whether something could be considered advertising or education depends on who benefits. Education will benefit learners (e.g. developers, designers, etc.), while advertising largely benefits the advertisers.</li>
-				
-				<li><strong>Surveys</strong> should only be posted in the <strong><code>#surveys</code></strong> channel. When posting a survey, please respect participants' desire for transparency around how their personal information will be used, by including all of the following:
+
+				<li><strong>Surveys</strong> should only be posted in the <strong><code>#ads-and-surveys</code></strong> channel. When posting a survey, please respect participants' desire for transparency around how their personal information will be used, by including all of the following:
 					<ul>
 						<li>The individual(s) and/or organization(s) running the survey.</li>
 						<li>How the responses will be used.</li>
@@ -94,6 +94,7 @@
 			<ul>
 				<li>If you are looking for work, post in <strong><code>#job-career-chat</code></strong>.</li>
 				<li>If you are hiring for one or more roles, post in <strong><code>#job-board</code></strong>.</li>
+				<li>If you are hiring for a smaller commitment, post in <strong><code>#freelance</code></strong>.</li>
 			</ul>
 			<p>Failure to adhere to our solicitation policies after 3 notices will result in a permanent ban.</p>
 		</section>
@@ -108,7 +109,7 @@
 				<li>Repeated, unwanted requests are considered harassment and will not be tolerated.</li>
 			</ul>
 		</section>
-		
+
 		<section id="harassment">
 			<h2 id="harassment">Harassment</h2>
 			<p>Harassment includes:</p>
@@ -128,27 +129,27 @@
 				<li>Calling and/or emailing members without their prior consent</li>
 			</ul>
 		</section>
-		
+
 		<section aria-label="reporting">
 			<h2 id="reporting">Reporting</h2>
 			<p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact the lead admin in a DM (@marcysutton). They'll respond as promptly as they can.</p>
 			<p>We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them. We will not name harassment victims without their affirmative consent.</p>
 		</section>
-		
+
 		<section aria-labelledby="consequences">
 			<h2 id="consequences">Consequences</h2>
 			<p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>
 			<p>If a participant engages in harassing behavior, the admins may take any action they deem appropriate, up to and including deactivation from this Slack and identifying the participant publicly as someone about whom we've received complaints.</p>
 			<p>Participants should not change their handle or create a new one to avoid accountability for past actions. Also, if someone has been banned from the group they are not allowed to rejoin under a different email address, name, etc.</p>
 		</section>
-		
+
 		<section aria-labelledby="logs-records">
 			<h2 id="logs-records">Logs and Records</h2>
 			<p><strong>Please be mindful that things you say here may at some point become public</strong>. We cannot prevent people from screencapping or otherwise logging this Slack. We also can't guarantee that every member's login credentials and logged-in devices are secure. Files uploaded here can be downloaded by anyone with a login. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.</p>
 			<p>We ask that members not repeatedly delete messages from Slack channels, either, as it affects the search history and creates gaps when users have commented.</p>
 			<p>If you have issues with a shared channel or any other related matter, contact Marcy Sutton for assistance.</p>
 		</section>
-		
+
 		<section aria-labelledby="credits">
 			<h2 id="credits">Credits and License</h2>
 			<p>This code of conduct is based on Annalee Flower Horne's <a href="https://gist.github.com/annalee/2cddeff11357c3a8a613583ebca4dc17">Sample Slack Code of Conduct</a>, which is in turn based on Geek Feminism's <a href="http://geekfeminism.wikia.com/wiki/Community_anti-harassment/Policy" rel="nofollow">Community Anti-Harassment Policy</a>. We have adapted the Sample Slack Code of Conduct for our own use under the terms of the <a href="https://creativecommons.org/licenses/by/4.0/" rel="nofollow">Creative Commons Attribution License</a>.</p>
@@ -156,13 +157,13 @@
 			<h2 id="contributing">Contributing</h2>
 			<p>This Code of Conduct can be found on GitHub! Suggestions and contributions are welcome: <a href="https://github.com/accessibility/a11yslack">https://github.com/accessibility/a11yslack</a></p>
 		</section>
-	
+
 	</main>
 
 	<footer class="container-fluid text-center bg-dark text-light">
 		<p>Brought to you by people who care about making the web accessible - &copy; 2024</p>
 	</footer>
-	  
+
 	<!-- Optional JavaScript -->
 	<!-- jQuery first, then Popper.js, then Bootstrap JS -->
 	<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>


### PR DESCRIPTION
The channel names in the _Solicitation Policy_ section have been updated to provide greater clarity on where specific content should be posted.