### PR TITLE
Fixed labeling for sections

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -21,7 +21,7 @@
 	<main class="container">
 		<h1>A11Y (Accessibility) Slack Community Code of Conduct</h1>
 
-		<section id="welcome">
+		<section aria-labelledby="welcome">
 			<h2 id="welcome">Welcome!</h2>
 			<p>A11y is a Slack community of individuals passionate about accessibility who voice their opinions. It is a space to ask questions, help other people figure stuff out or chat about accessibility in general.</p>
 			<p>The current admins are:</p>
@@ -110,7 +110,7 @@
 			</ul>
 		</section>
 
-		<section id="harassment">
+		<section aria-labelledby="harassment">
 			<h2 id="harassment">Harassment</h2>
 			<p>Harassment includes:</p>
 			<ul>
@@ -130,7 +130,7 @@
 			</ul>
 		</section>
 
-		<section aria-label="reporting">
+		<section aria-labelledby="reporting">
 			<h2 id="reporting">Reporting</h2>
 			<p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact the lead admin in a DM (@marcysutton). They'll respond as promptly as they can.</p>
 			<p>We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them. We will not name harassment victims without their affirmative consent.</p>


### PR DESCRIPTION
A couple of sections had `id`s that duplicated those of their headings. 
Another one had `aria-label` set to what looked like the ID of the section heading.

This PR changes them to `aria-labelledby`.